### PR TITLE
Should be posible to override the width if the slideshow is not shown in full width of screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ export default class SlideshowTest extends Component {
 | --- | :---: | :---: | :---: | --- |
 | `dataSource` | bool | required | - | slideshow data |
 | `height` | number | optional | 200 | container height |
+| `width` | number | optional | - | window width |
 | `position` | number | optional | - | set position slideshow |
 | `scrollEnabled` | bool | optional | true | enable / disable scrolling |
 | `overlay` | bool | optional | false | background overlay |

--- a/Slideshow.js
+++ b/Slideshow.js
@@ -41,8 +41,7 @@ const styles = StyleSheet.create({
     opacity: 1,
   },
   containerImage : {
-    flex: 1,
-    width: Dimensions.get('window').width,
+    flex: 1
   },
   overlay: {
     opacity: 0.5,
@@ -78,9 +77,14 @@ export default class Slideshow extends Component {
     this.state = {
       position: 0,
       height: Dimensions.get('window').width * (4 / 9),
-      width: Dimensions.get('window').width,
+      width: props.width || Dimensions.get('window').width,
       scrolling: false,
     };
+  }
+
+  containerImageStyle() {
+    const style = styles.containerImage
+    style.width = this.props.width || Dimensions.get('window').width
   }
 
   _onRef(ref) {
@@ -130,7 +134,7 @@ export default class Slideshow extends Component {
   }
 
   componentWillMount() {
-    const width = this.state.width;
+    const width = this.props.width || this.state.width;
 
     let release = (e, gestureState) => {
       const width = this.state.width;
@@ -156,13 +160,14 @@ export default class Slideshow extends Component {
     this._panResponder = PanResponder.create({
       onPanResponderRelease: release
     });
-
-    this._interval = setInterval(() => {
-      const newWidth = Dimensions.get('window').width;
-      if (newWidth !== this.state.width) {
-        this.setState({width: newWidth});
-      }
-    }, 16);
+    if (!this.props.width) {
+      this._interval = setInterval(() => {
+        const newWidth = Dimensions.get('window').width;
+        if (newWidth !== this.state.width) {
+          this.setState({width: newWidth});
+        }
+      }, 16);
+    }
   }
 
   componentWillUnmount() {
@@ -170,7 +175,7 @@ export default class Slideshow extends Component {
   }
 
   render() {
-    const width = this.state.width;
+    const width = this.props.width || this.state.width;
     const height = this.props.height || this.state.height;
     const position = this._getPosition();
     return (
@@ -207,7 +212,7 @@ export default class Slideshow extends Component {
               </View>
             );
             const imageComponentWithOverlay = (
-              <View key={index} style={styles.containerImage}>
+              <View key={index} style={this.containerImageStyle()}>
                 <View style={styles.overlay}>
                   <Image
                     source={imageObject}
@@ -326,6 +331,7 @@ Slideshow.propTypes = {
 	indicatorSelectedColor: PropTypes.string,
 	height: PropTypes.number,
 	position: PropTypes.number,
+  width: PropTypes.number,
   scrollEnabled: PropTypes.bool,
   containerStyle: PropTypes.object,
   overlay: PropTypes.bool,


### PR DESCRIPTION
Like this component, but when width is calculated from full width of device, images is not centered in the correctly. This fixes this by adding a own property for width that can be managed from parent view.